### PR TITLE
make sure prime cyclic groups are simple

### DIFF
--- a/html/SubgroupInfo.html
+++ b/html/SubgroupInfo.html
@@ -24,11 +24,11 @@
         <a href="" action="SubgroupInfo.showSubgroupLattice('MTElement')">multiplication table</a>, or
         by calculation:</p>
     <p class='gapcode' data-built-in-code-type='subgroup lattice'></p>
-    <p id="simple">None of the subgroups on the list below is
+    <p id="simple">None of the proper, nontrivial subgroups on the list below is
         <a href="./help/rf-groupterms/index.html#normal-subgroup">normal</a>.
         For this reason, ${MathML.sans(Group.name)} is a
         <a href="./help/rf-groupterms/index.html#simple-group">simple</a> group.</p>
-    <p id="not-simple">At least one of the subgroups on the list below is
+    <p id="not-simple">At least one of the proper, nontrivial subgroups on the list below is
         <a href="./help/rf-groupterms/index.html#normal-subgroup">normal</a>.
         For this reason, ${MathML.sans(Group.name)} is not a
         <a href="./help/rf-groupterms/index.html#simple-group">simple</a> group.</p>

--- a/js/BasicGroup.js
+++ b/js/BasicGroup.js
@@ -115,7 +115,7 @@ class BasicGroup {
    get isSimple() /*: boolean */ {
       if (this._isSimple == undefined) {
          this._isSimple =
-            this.subgroups.length = 2 ||  /* nontrivial prime cyclic */
+            this.subgroups.length == 2 ||  /* nontrivial prime cyclic */
             (this.subgroups.length > 2 && !this.subgroups.some( /* a normal subgroup exists that is proper and nontrivial */
                (el, inx) => this.isNormal(el) && inx != 0 && inx != (this.subgroups.length - 1) ) );
       }

--- a/js/BasicGroup.js
+++ b/js/BasicGroup.js
@@ -115,9 +115,9 @@ class BasicGroup {
    get isSimple() /*: boolean */ {
       if (this._isSimple == undefined) {
          this._isSimple =
-            this.subgroups.length > 2 &&
-            !this.subgroups.some(
-               (el, inx) => this.isNormal(el) && inx != 0 && inx != (this.subgroups.length - 1) );
+            this.subgroups.length <=2 || 
+            (!this.subgroups.some(
+               (el, inx) => this.isNormal(el) && inx != 0 && inx != (this.subgroups.length - 1) ) );
       }
       return this._isSimple;
    }

--- a/js/BasicGroup.js
+++ b/js/BasicGroup.js
@@ -115,8 +115,8 @@ class BasicGroup {
    get isSimple() /*: boolean */ {
       if (this._isSimple == undefined) {
          this._isSimple =
-            this.subgroups.length <=2 || 
-            (!this.subgroups.some(
+            this.subgroups.length = 2 ||  /* nontrivial prime cyclic */
+            (this.subgroups.length > 2 && !this.subgroups.some( /* a normal subgroup exists that is proper and nontrivial */
                (el, inx) => this.isNormal(el) && inx != 0 && inx != (this.subgroups.length - 1) ) );
       }
       return this._isSimple;


### PR DESCRIPTION
I think that `||` evaluates like in Python, where if the first one is true then it just immediately returns true, right?  Otherwise we should keep the line about `>2`.